### PR TITLE
Open wp-admin after env start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "preenv:*": "nvm install lts/* && nvm use",
-    "env:start": "npx wp-env start",
+    "env:start": "npx wp-env start && npx open http://localhost:4759/wp-admin/",
     "env:stop": "npx wp-env stop"
   },
   "author": "Dave Smith <dave.smith@automattic.com>",


### PR DESCRIPTION
Minor quality of life improvement: the port is a bit special and could be easy to forget. So the idea here would be to open wp-admin directly after starting the environment. This way one wouldn't have to check the documentation for the port.